### PR TITLE
Fix import of two releases of one ReleaseHead

### DIFF
--- a/app/importers/persist_brainz_release_head.rb
+++ b/app/importers/persist_brainz_release_head.rb
@@ -18,10 +18,10 @@ class PersistBrainzReleaseHead < PersistBrainzBase
   end
 
   def find_already_existing
-    FindByCodesService.call(
-      codes_hash:  blueprint.codes_hash,
-      model_class: ReleaseHead
-    )
+    by_code = FindByCodesService.call(codes_hash: { brainz_code: code }, model_class: ReleaseHead)
+    return by_code if by_code
+
+    FindByCodesService.call(codes_hash: blueprint.codes_hash, model_class: ReleaseHead)
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/spec/importers/persist_brainz_release_head_spec.rb
+++ b/spec/importers/persist_brainz_release_head_spec.rb
@@ -10,31 +10,49 @@ RSpec.describe PersistBrainzReleaseHead do
       TestData.by_name(:brainz_release_group_arise).blueprint
     end
 
-    let(:release_head) do
-      persister = described_class.new(
+    let(:persister) do
+      described_class.new(
         code:         blueprint.brainz_code,
         import_order: FactoryBot.create(:brainz_import_order),
         proxy:        FakeProxy.new
       )
-
-      allow(persister).to receive(:persist_artist_credit)
-        .and_return(FactoryBot.create(:artist_credit))
-      allow(persister).to receive(:blueprint)
-        .and_return(blueprint)
-      persister.persist
     end
 
-    it 'returns a SingleHead' do
-      expect(release_head).to be_instance_of(SingleHead)
+    let(:release_head) { persister.persist }
+
+    context 'when the ReleaseHead does not exist in the database' do
+      before do
+        allow(persister).to receive(:persist_artist_credit).and_return(FactoryBot.create(:artist_credit))
+        allow(persister).to receive(:blueprint).and_return(blueprint)
+
+        persister.call
+      end
+
+      it 'returns a SingleHead' do
+        expect(release_head).to be_instance_of(SingleHead)
+      end
+
+      it 'sets the ImportOrder' do
+        expect(release_head.import_order).to be_kind_of(ImportOrder)
+      end
+
+      it 'sets the brainz_code' do
+        expect(release_head.brainz_code).to eq('5fc9ba9d-bc39-38fc-a479-eadbf0f3a933')
+      end
     end
 
-    it 'sets the ImportOrder' do
-      expect(release_head.import_order).to be_kind_of(ImportOrder)
-    end
+    context 'when the ReleaseHead exists in the database' do
+      before do
+        FactoryBot.create(:release_head, brainz_code: '5fc9ba9d-bc39-38fc-a479-eadbf0f3a933')
 
-    it 'sets the brainz_code' do
-      expect(release_head.brainz_code)
-        .to eq('5fc9ba9d-bc39-38fc-a479-eadbf0f3a933')
+        allow(persister).to receive(:persist_artist_credit).and_return(FactoryBot.create(:artist_credit))
+        persister.proxy.lock 
+        persister.call
+      end
+
+      it 'returns a SingleHead' do
+        expect(release_head).to be_instance_of(SingleHead)
+      end
     end
   end
 end


### PR DESCRIPTION
Now it is possible to import two MusicBrain releases of
one ReleaseGroup.