### PR TITLE
Start Redis in docker-compose.ci.yml

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -23,12 +23,14 @@ x-ci-app: &ci-app
     RAILS_ENV: test
     RACK_ENV: test
     BUNDLE_PATH: /usr/src/app/vendor/bundle
+    REDIS_URL: redis://@redis:6379/1
   volumes:
     - .:/usr/src/app:cached
-
   depends_on:
     postgres:
       condition: service_healthy
+    redis:
+      condition: service_started
 
 services:
   postgres:
@@ -43,6 +45,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: none
+
+  redis:
+    image: redis:4.0.14-alpine
+    mem_limit: 64m
+    ports:
+      - "127.0.0.1:6379:6379"
+    restart: on-failure
     logging:
       driver: none
 


### PR DESCRIPTION
Now tests pass even if the Redis-container is not running.