### PR TITLE
Use postgres:13.2-alpine in docker-compose.ci.yml

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -34,7 +34,7 @@ x-ci-app: &ci-app
 
 services:
   postgres:
-    image: postgres:12.3-alpine
+    image: postgres:13.2-alpine
     mem_limit: 64m
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
Now docker-compose.yml and docker-compose.ci.yml are even.